### PR TITLE
Improves, add ActiveRecord::ConnectionNotEstablished exception

### DIFF
--- a/lib/active_record/pg_reconnect.rb
+++ b/lib/active_record/pg_reconnect.rb
@@ -27,7 +27,7 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
           reconnect!
         end
         send(unsafe_method, *args, **kwargs, &block)
-      rescue ActiveRecord::StatementInvalid => e
+      rescue ActiveRecord::StatementInvalid, ActiveRecord::ConnectionNotEstablished => e
         @reconnection_required = e.cause.is_a? PG::ConnectionBad
         raise e
       end

--- a/lib/active_record/pg_reconnect.rb
+++ b/lib/active_record/pg_reconnect.rb
@@ -4,14 +4,13 @@ require 'active_record'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-
-  RECONNECTABLE_METHODS = [
-    :execute,
-    :exec_query,
-    :exec_insert,
-    :exec_update,
-    :exec_delete,
-    :query
+  RECONNECTABLE_METHODS = %i[
+    execute
+    exec_query
+    exec_insert
+    exec_update
+    exec_delete
+    query
   ].freeze
 
   RECONNECTABLE_METHODS.each do |method|
@@ -21,16 +20,16 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
 
     private unsafe_method
 
-    define_method method do |*args, &block|
+    define_method method do |*args, **kwargs, &block|
       begin
         if reconnection_required?
           @reconnection_required = false
           reconnect!
         end
-        send(unsafe_method, *args, &block)
-      rescue ActiveRecord::StatementInvalid => ex
-        @reconnection_required = ex.cause.is_a? PG::ConnectionBad
-        raise ex
+        send(unsafe_method, *args, **kwargs, &block)
+      rescue ActiveRecord::StatementInvalid => e
+        @reconnection_required = e.cause.is_a? PG::ConnectionBad
+        raise e
       end
     end
   end
@@ -38,5 +37,4 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   def reconnection_required?
     @reconnection_required ||= false
   end
-
 end


### PR DESCRIPTION
Hello! 
We are developing a high-load service and we encountered the problem that in case of problems with the database the application returned an error before it was restarted. This caused problems. Your gem helped to fix this behavior, thank you.
However, we noticed that calling the reconnect! method causes an ActiveRecord::ConnectionNotEstablished error if the database has not yet been up, and this also causes the need to restart the application.
We have added this exception to the handling. Also we fixed the problem with keyword arguments.